### PR TITLE
Search for Highlight.js styles in main node_modules folder too

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,16 @@ var hljs = require('highlight.js');
 var fs = require('fs');
 var mime = require('mime');
 var util = require('util');
+var path = require('path');
 
 function NOCat() {
 	this._style = null;
-	this._stylePath = __dirname + '/node_modules/highlight.js/styles';
+    var stylePath = __dirname + '/node_modules/highlight.js/styles';
+    if (!fs.existsSync(stylePath)){
+      stylePath = path.join(__dirname, '../highlight.js/styles');
+    }
+
+	this._stylePath = stylePath;
 	this._mime2language = require('./mime2language');
 
 	this.setStyle = function(styleName) {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ var path = require('path');
 
 function NOCat() {
 	this._style = null;
-    var stylePath = __dirname + '/node_modules/highlight.js/styles';
-    if (!fs.existsSync(stylePath)){
-      stylePath = path.join(__dirname, '../highlight.js/styles');
-    }
+	var stylePath = __dirname + '/node_modules/highlight.js/styles';
+	if (!fs.existsSync(stylePath)){
+		stylePath = path.join(__dirname, '../highlight.js/styles');
+	}
 
 	this._stylePath = stylePath;
 	this._mime2language = require('./mime2language');


### PR DESCRIPTION
Hi, @hash-bang 

I have a situation when highlight.js is installed in main node_modules folder, so subdir node_modules does not exist. I added support for searching styles in both folders.
